### PR TITLE
Tune surf example with Momentum Mod as reference

### DIFF
--- a/examples/surf.rs
+++ b/examples/surf.rs
@@ -123,6 +123,8 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
     CharacterController {
         acceleration_hz: 10.0,
         air_acceleration_hz: 150.0,
+        speed: 6.0,
+        gravity: 23.0,
         ..default()
     },
     RigidBody::Kinematic,
@@ -186,7 +188,7 @@ impl PlayerInput {
                 ),
                 (
                     Action::<RotateCamera>::new(),
-                    Scale::splat(0.04),
+                    Scale::splat(0.03),
                     Bindings::spawn((
                         Spawn(Binding::mouse_motion()),
                         Axial::right_stick()


### PR DESCRIPTION
I used a very simplistic technique of measuring jump time and walk speed with a stopwatch to match the gravity and walk speed of Momentum Mod, respectively.