### PR TITLE
Exclude macOS from using PresentMode::Mailbox.

### DIFF
--- a/examples/playground.rs
+++ b/examples/playground.rs
@@ -5,7 +5,7 @@ use bevy::{
     image::{ImageAddressMode, ImageSampler, ImageSamplerDescriptor},
     input::common_conditions::input_just_pressed,
     prelude::*,
-    window::{CursorGrabMode, CursorOptions, PresentMode},
+    window::{CursorGrabMode, CursorOptions},
 };
 use bevy_ahoy::{PickupHoldConfig, PickupPullConfig, prelude::*};
 use bevy_enhanced_input::prelude::{Press, *};
@@ -27,7 +27,8 @@ fn main() -> AppExit {
                 })
                 .set(WindowPlugin {
                     primary_window: Window {
-                        present_mode: PresentMode::Mailbox,
+                        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
+                        present_mode: bevy::window::PresentMode::Mailbox,
                         ..default()
                     }
                     .into(),

--- a/examples/surf.rs
+++ b/examples/surf.rs
@@ -42,7 +42,7 @@ fn main() -> AppExit {
                         #[cfg(not(target_arch = "wasm32"))]
                         resolution: WindowResolution::new(1920, 1080),
                         fit_canvas_to_parent: true,
-                        #[cfg(not(target_arch = "wasm32"))]
+                        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
                         present_mode: bevy::window::PresentMode::Mailbox,
                         ..default()
                     }


### PR DESCRIPTION
## Reason
Mailbox present mode is not supported on macOS (Metal), so it must be disabled there.

## Change
Added target_os = "macos" to the compile-time disqualifier for PresentMode::Mailbox.
Also removed wasm in the playground