### PR TITLE
Replace `Transform` for orientation with `Quat`.

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2,6 +2,7 @@ use avian_pickup::input::{AvianPickupAction, AvianPickupInput};
 use bevy_time::Stopwatch;
 
 use crate::CharacterControllerState;
+use crate::kcc::{forward, right};
 use crate::prelude::*;
 
 use crate::fixed_update_utils::did_fixed_timestep_run_this_frame;
@@ -118,10 +119,10 @@ fn apply_global_movement(
 ) {
     if let Ok((mut accumulated_inputs, state)) = query.get_mut(movement.context) {
         let global_move = movement.value;
-        let right = state.orientation.right();
-        let forward = state.orientation.forward();
-        let local_x = global_move.dot(*right);
-        let local_y = global_move.dot(*forward);
+        let right = right(state.orientation);
+        let forward = forward(state.orientation);
+        let local_x = global_move.dot(right);
+        let local_y = global_move.dot(forward);
         accumulated_inputs.last_movement = Some(Vec2::new(local_x, local_y));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ fn setup_collider(
 #[derive(Component, Clone, Reflect, Debug)]
 #[reflect(Component)]
 pub struct CharacterControllerState {
-    pub orientation: Transform,
+    pub orientation: Quat,
     pub base_velocity: Vec3,
     pub base_angular_velocity: Vec3,
     #[reflect(ignore)]
@@ -337,7 +337,7 @@ impl Default for CharacterControllerState {
         Self {
             base_velocity: Vec3::ZERO,
             base_angular_velocity: Vec3::ZERO,
-            orientation: Transform::IDENTITY,
+            orientation: Quat::IDENTITY,
             // late initialized
             standing_collider: default(),
             crouching_collider: default(),


### PR DESCRIPTION
Instead of using a Transform to define the orientation, we use a `Quat` instead. This makes the intention that the translation is not needed more obvious.