### PR TITLE
Fix `CharacterLook` when actions are not fired from the default schedule

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,8 +4,8 @@ use avian_pickup::actor::AvianPickupActor;
 use bevy_ecs::{lifecycle::HookContext, relationship::Relationship, world::DeferredWorld};
 
 use crate::{
-    kcc::spin_character_look, prelude::*, CharacterControllerDerivedProps,
-    CharacterControllerState, CharacterLook,
+    CharacterControllerDerivedProps, CharacterControllerState, CharacterLook,
+    kcc::spin_character_look, prelude::*,
 };
 
 pub struct AhoyCameraPlugin;


### PR DESCRIPTION
There seems to be a scheduling issue with camera's rotation / `CharacterLook` syncing when input is not set to default `PreUpdate`. In other words, not using 
```rust
app.add_input_context::<PlayerInput>()
```
but something like 
```rust
app.add_input_context_to::<FixedPreUpdate, PlayerInput>()
``` 
(for example, [`lightyear` does that](https://github.com/cBournhonesque/lightyear/blob/4c124a79bbf79fd18f233dd5990b5ede2c04d368/lightyear_inputs_bei/src/plugin.rs#L65))

Updating `CharacterLook` alongside camera's rotation seems to fix the issue, but I'm not sure about platform rotation, it may be overwriting that now ? I'm not sure how can I check that easily. 