### PR TITLE
Feature gate `avian_pickup`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "rand",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ categories = ["game-development"]
 include = ["/src", "/license*", "/examples"]
 
 [features]
-default = []
-serialize = ["dep:serde", "avian3d/serialize", "bevy_math/serialize"]
+default = ["pickup"]
+serialize = ["dep:serde", "avian3d/serialize", "bevy_math/serialize", "avian_pickup/serialize"]
+pickup = ["dep:avian_pickup"]
 
 [dependencies]
-avian3d = { version = "0.6.0-rc.1", default-features = false, features = ["default-collider", "3d", "f32"] }
+avian3d = { version = "0.6.0-rc.1", default-features = false, features = ["parry-f32", "3d", "f32"] }
 bevy_ecs = { version = "0.18", default-features = false }
 bevy_app = { version = "0.18", default-features = false }
 bevy_derive = { version = "0.18", default-features = false }
@@ -27,7 +28,7 @@ bevy_transform = { version = "0.18", default-features = false }
 bevy_time = { version = "0.18", default-features = false }
 bevy_enhanced_input = { version = "0.24", default-features = false }
 tracing = { version = "0.1", default-features = false }
-avian_pickup = "0.5.0-rc.1"
+avian_pickup = { version = "0.5.0-rc.1", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,5 +1,6 @@
 use std::{f32::consts::TAU, time::Duration};
 
+#[cfg(feature = "pickup")]
 use avian_pickup::actor::AvianPickupActor;
 use bevy_ecs::{lifecycle::HookContext, relationship::Relationship, world::DeferredWorld};
 
@@ -30,7 +31,8 @@ impl Plugin for AhoyCameraPlugin {
 
 #[derive(Component, Clone, Copy, Debug)]
 #[relationship(relationship_target = CharacterControllerCamera)]
-#[require(AvianPickupActor, Transform)]
+#[require(Transform)]
+#[cfg_attr(feature = "pickup", require(AvianPickupActor))]
 #[component(on_add = Self::on_add)]
 pub struct CharacterControllerCameraOf {
     #[relationship]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "pickup")]
 use avian_pickup::input::{AvianPickupAction, AvianPickupInput};
 use bevy_time::Stopwatch;
 
@@ -17,9 +18,6 @@ impl Plugin for AhoyInputPlugin {
             .add_observer(apply_tac)
             .add_observer(apply_crouch)
             .add_observer(apply_swim_up)
-            .add_observer(apply_drop)
-            .add_observer(apply_pull)
-            .add_observer(apply_throw)
             .add_observer(apply_crane)
             .add_observer(apply_mantle)
             .add_observer(apply_climbdown)
@@ -30,6 +28,11 @@ impl Plugin for AhoyInputPlugin {
                     .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
             )
             .add_systems(PreUpdate, tick_timers.in_set(EnhancedInputSystems::Update));
+
+        #[cfg(feature = "pickup")]
+        app.add_observer(apply_drop)
+            .add_observer(apply_pull)
+            .add_observer(apply_throw);
     }
 }
 
@@ -77,14 +80,17 @@ pub struct RotateCamera;
 #[action_output(f32)]
 pub struct YankCamera;
 
+#[cfg(feature = "pickup")]
 #[derive(Debug, InputAction)]
 #[action_output(bool)]
 pub struct PullObject;
 
+#[cfg(feature = "pickup")]
 #[derive(Debug, InputAction)]
 #[action_output(bool)]
 pub struct DropObject;
 
+#[cfg(feature = "pickup")]
 #[derive(Debug, InputAction)]
 #[action_output(bool)]
 pub struct ThrowObject;
@@ -178,6 +184,7 @@ fn apply_climbdown(
     }
 }
 
+#[cfg(feature = "pickup")]
 fn apply_pull(
     crouch: On<Fire<PullObject>>,
     mut avian_pickup_input_writer: MessageWriter<AvianPickupInput>,
@@ -194,6 +201,7 @@ fn apply_pull(
     });
 }
 
+#[cfg(feature = "pickup")]
 fn apply_drop(
     crouch: On<Fire<DropObject>>,
     mut avian_pickup_input_writer: MessageWriter<AvianPickupInput>,
@@ -210,6 +218,7 @@ fn apply_drop(
     });
 }
 
+#[cfg(feature = "pickup")]
 fn apply_throw(
     crouch: On<Fire<ThrowObject>>,
     mut avian_pickup_input_writer: MessageWriter<AvianPickupInput>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,24 +16,28 @@ pub mod prelude {
     };
 
     pub use crate::{
-        AhoyPlugins, AhoySystems, CharacterController, CharacterControllerState, PickupConfig,
+        AhoyPlugins, AhoySystems, CharacterController, CharacterControllerState,
         camera::{CharacterControllerCamera, CharacterControllerCameraOf},
         input::{
-            Climbdown, Crane, Crouch, DropObject, GlobalMovement, Jump, Mantle, Movement,
-            PullObject, RotateCamera, SwimUp, Tac, ThrowObject, YankCamera,
+            Climbdown, Crane, Crouch, GlobalMovement, Jump, Mantle, Movement, RotateCamera, SwimUp,
+            Tac, YankCamera,
         },
-        pickup,
         water::{Water, WaterLevel, WaterState},
+    };
+
+    #[cfg(feature = "pickup")]
+    pub use crate::{
+        PickupConfig,
+        input::{DropObject, PullObject, ThrowObject},
+        pickup,
     };
 }
 
-pub use crate::{
-    camera::AhoyCameraPlugin, dynamics::AhoyDynamicPlugin,
-    fixed_update_utils::AhoyFixedUpdateUtilsPlugin, input::AhoyInputPlugin, kcc::AhoyKccPlugin,
-    pickup_glue::AhoyPickupGluePlugin, water::AhoyWaterPlugin,
-};
-use crate::{input::AccumulatedInput, prelude::*};
+#[cfg(feature = "pickup")]
+pub use crate::pickup_glue::AhoyPickupGluePlugin;
+#[cfg(feature = "pickup")]
 use avian_pickup::AvianPickupPlugin;
+#[cfg(feature = "pickup")]
 pub use avian_pickup::{
     self as pickup,
     prelude::{
@@ -42,6 +46,13 @@ pub use avian_pickup::{
         AvianPickupActorThrowConfig as PickupThrowConfig,
     },
 };
+
+pub use crate::{
+    camera::AhoyCameraPlugin, dynamics::AhoyDynamicPlugin,
+    fixed_update_utils::AhoyFixedUpdateUtilsPlugin, input::AhoyInputPlugin, kcc::AhoyKccPlugin,
+    water::AhoyWaterPlugin,
+};
+use crate::{input::AccumulatedInput, prelude::*};
 use avian3d::character_controller::move_and_slide::MoveHitData;
 use bevy_app::PluginGroupBuilder;
 use bevy_ecs::{intern::Interned, schedule::ScheduleLabel};
@@ -53,13 +64,15 @@ mod dynamics;
 mod fixed_update_utils;
 pub mod input;
 mod kcc;
+#[cfg(feature = "pickup")]
 mod pickup_glue;
 mod water;
 
 /// Plugin group for Ahoy's internal plugins.
 ///
 /// It requires you to add [`PhysicsPlugins`] and [`EnhancedInputPlugin`] to work properly.
-/// Also adds [`AvianPickupPlugin`].
+///
+/// Also adds [`AvianPickupPlugin`] if `pickup` feature is enabled.
 pub struct AhoyPlugins {
     schedule: Interned<dyn ScheduleLabel>,
 }
@@ -83,7 +96,7 @@ impl Default for AhoyPlugins {
 
 impl PluginGroup for AhoyPlugins {
     fn build(self) -> PluginGroupBuilder {
-        PluginGroupBuilder::start::<Self>()
+        let plugin = PluginGroupBuilder::start::<Self>()
             .add(AhoySchedulePlugin {
                 schedule: self.schedule,
             })
@@ -94,11 +107,16 @@ impl PluginGroup for AhoyPlugins {
             })
             .add(AhoyWaterPlugin)
             .add(AhoyFixedUpdateUtilsPlugin)
-            .add(AhoyPickupGluePlugin)
             .add(AhoyDynamicPlugin {
                 schedule: self.schedule,
-            })
+            });
+
+        #[cfg(feature = "pickup")]
+        let plugin = plugin
             .add(AvianPickupPlugin::default())
+            .add(AhoyPickupGluePlugin);
+
+        plugin
     }
 }
 


### PR DESCRIPTION
Less compilation and less observers/systems for projects in which pickup isn't used. 

I left it in the *default* feature set to not break any existing projects that just do `bevy_ahoy = "..."` and then use pickup. I have also added `avian_pickup`'s *serialize* to `bevy_ahoy` own *serialize* feature.