### PR TITLE
Make the input types impl MapEntities.

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "pickup")]
 use avian_pickup::input::{AvianPickupAction, AvianPickupInput};
+use bevy_ecs::entity::MapEntities;
 use bevy_time::Stopwatch;
 
 use crate::CharacterControllerState;
@@ -96,7 +97,7 @@ pub struct DropObject;
 pub struct ThrowObject;
 
 /// Input accumulated since the last fixed update loop. Is cleared after every fixed update loop.
-#[derive(Component, Clone, Reflect, PartialEq, Default, Debug)]
+#[derive(Component, Clone, Reflect, PartialEq, Default, Debug, MapEntities)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use crate::{
 use crate::{input::AccumulatedInput, prelude::*};
 use avian3d::character_controller::move_and_slide::MoveHitData;
 use bevy_app::PluginGroupBuilder;
-use bevy_ecs::{intern::Interned, schedule::ScheduleLabel};
+use bevy_ecs::{entity::MapEntities, intern::Interned, schedule::ScheduleLabel};
 use bevy_time::Stopwatch;
 use core::time::Duration;
 
@@ -283,7 +283,7 @@ impl Default for CharacterController {
 /// The look direction for the character.
 ///
 /// Usually, this is populated by the camera.
-#[derive(Component, Clone, Reflect, PartialEq, Debug, Default)]
+#[derive(Component, Clone, Reflect, PartialEq, Debug, Default, MapEntities)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]


### PR DESCRIPTION
For reasons I don't understand, the input systems of `lightyear` require that the input structs implement `MapEntities`. There isn't really any harm, it just looks a little silly here.