### PR TITLE
Fix `serialize` feature enabling `avian_pickup`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include = ["/src", "/license*", "/examples"]
 
 [features]
 default = ["pickup"]
-serialize = ["dep:serde", "avian3d/serialize", "bevy_math/serialize", "avian_pickup/serialize"]
+serialize = ["dep:serde", "avian3d/serialize", "bevy_math/serialize", "avian_pickup?/serialize"]
 pickup = ["dep:avian_pickup"]
 
 [dependencies]


### PR DESCRIPTION
Enabling `serialize` feature also enabled the optional `avian_pickup` crate, even when `pickup` feature was disabled. I didn't know about `crate?/feature` syntax... 

Continuation of #76.